### PR TITLE
Change port to a registered one

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ receivers:
   - name: prommsd
     webhook_configs:
       - send_resolved: false
-        url: http://localhost:9111/alert
+        url: http://localhost:9799/alert
 ```
 
 It is possible to use `continue: true` and deliver to additional prommsd

--- a/cmd/prommsd/main.go
+++ b/cmd/prommsd/main.go
@@ -2,7 +2,7 @@
 // pass them to an alert hook.
 //
 // The alert handler will be available at '/alert' on the address this listens
-// on (e.g. http://localhost:9111/alert).
+// on (e.g. http://localhost:9799/alert).
 package main
 
 import (
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	flagListenAddr  = flag.String("listen", ":9111", "Where to listen for HTTP requests")
+	flagListenAddr  = flag.String("listen", ":9799", "Where to listen for HTTP requests")
 	flagExternalURL = flag.String("external-url", "", "URL where this is accessible to users")
 	flagVersion     = flag.Bool("version", false, "Print version information")
 )

--- a/configs/alertmanager.yml
+++ b/configs/alertmanager.yml
@@ -43,7 +43,7 @@ receivers:
   - name: prommsd
     webhook_configs:
       - send_resolved: false
-        url: http://localhost:9111/alert
+        url: http://localhost:9799/alert
   - name: pager
     webhook_configs:
       - url: http://localhost:1111


### PR DESCRIPTION
Now on https://github.com/prometheus/prometheus/wiki/Default-port-allocations