### PR TITLE
Use a non-zero duration for group_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ route:
       - match:
           severity: heartbeat
         receiver: prommsd
-        # Always set group_interval to 0s, prommsd does its own grouping.
-        group_interval: 0s
+        # Always set group_interval to a very short non-zero
+        # duration: prommsd does its own grouping and alertmanager
+        # requires non-zero.
+        group_interval: 1s
         repeat_interval: 1m
 ```
 


### PR DESCRIPTION
Alertmanager rejects zero: https://github.com/prometheus/alertmanager/blob/v0.24.0/config/config.go#L786

This replaces <https://github.com/G-Research/prommsd/pull/10> as there's a branch configuration problem which prevents us from updating, renaming or removing any branches.