### PR TITLE
Handle empty strings from environment variables

### DIFF
--- a/pkg/tracing/processor.go
+++ b/pkg/tracing/processor.go
@@ -47,7 +47,10 @@ func NewOTLPExporterFromEnv(ctx context.Context) (sdktrace.SpanExporter, error) 
 }
 
 func NewProcessorsFromEnv(ctx context.Context) ([]sdktrace.SpanProcessor, error) {
-	enabled := strings.Split(strings.TrimSpace(os.Getenv("OTEL_TRACES_EXPORTER")), ",")
+	var enabled []string
+	if s := strings.TrimSpace(os.Getenv("OTEL_TRACES_EXPORTER")); s != "" {
+		enabled = strings.Split(s, ",")
+	}
 
 	// https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/#exporter-selection
 	// Default exporter should be "otlp"; however to preserve compatibiltiy

--- a/pkg/tracing/propagator.go
+++ b/pkg/tracing/propagator.go
@@ -17,7 +17,12 @@ func NewPropagatorsFromEnv() (propagation.TextMapPropagator, error) {
 	enabled := []string{"tracecontext", "baggage"}
 
 	if v, ok := os.LookupEnv("OTEL_PROPAGATORS"); ok {
-		enabled = strings.Split(strings.TrimSpace(v), ",")
+		if s := strings.TrimSpace(v); s != "" {
+			enabled = strings.Split(s, ",")
+		} else {
+			// Explicit empty string in the environment: clear the default.
+			enabled = nil
+		}
 	}
 
 	var propagators []propagation.TextMapPropagator


### PR DESCRIPTION
I misread strings.Split and hadn't picked up splitting `""` gives back `[""]`.